### PR TITLE
Task uplift

### DIFF
--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -8,18 +8,13 @@ on:
 jobs:
   build:
     name: Build on ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
     - uses: actions/checkout@v1
 
     - name: set up docker
       run: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Salakala123!" -p 1433:1433 --name sql1 --hostname sql1 -d mcr.microsoft.com/mssql/server:2019-CU18-ubuntu-20.04
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '6.x'
 
     - name: Build
       run: dotnet build

--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -9,18 +9,17 @@ jobs:
   build:
     name: Build on ubuntu
     runs-on: ubuntu-latest
-
-    - task: UseDotNet@2
-      inputs:
-        packageType: 'sdk'
-        version: '6.x' # or 8.0.302 
-        installationPath: $(Agent.ToolsDirectory)/dotnet
     
     steps:
     - uses: actions/checkout@v1
 
     - name: set up docker
       run: docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Salakala123!" -p 1433:1433 --name sql1 --hostname sql1 -d mcr.microsoft.com/mssql/server:2019-CU18-ubuntu-20.04
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '6.x'
 
     - name: Build
       run: dotnet build

--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -9,6 +9,12 @@ jobs:
   build:
     name: Build on ubuntu
     runs-on: ubuntu-latest
+
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        version: '6.x' # or 8.0.302 
+        installationPath: $(Agent.ToolsDirectory)/dotnet
     
     steps:
     - uses: actions/checkout@v1

--- a/Frends.Community.WindowsSQL.Tests/Frends.Community.WindowsSQL.Tests.csproj
+++ b/Frends.Community.WindowsSQL.Tests/Frends.Community.WindowsSQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
 	<LangVersion>Latest</LangVersion>
 
     <IsPackable>false</IsPackable>

--- a/Frends.Community.WindowsSQL.Tests/Frends.Community.WindowsSQL.Tests.csproj
+++ b/Frends.Community.WindowsSQL.Tests/Frends.Community.WindowsSQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<LangVersion>Latest</LangVersion>
 
     <IsPackable>false</IsPackable>

--- a/Frends.Community.WindowsSQL.Tests/Frends.Community.WindowsSQL.Tests.csproj
+++ b/Frends.Community.WindowsSQL.Tests/Frends.Community.WindowsSQL.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
 	<PackageReference Include="nunit" Version="3.10.1" />
 	<PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>

--- a/Frends.Community.WindowsSQL.Tests/UnitTest.cs
+++ b/Frends.Community.WindowsSQL.Tests/UnitTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +32,7 @@ namespace Frends.Community.WindowsSQL.Tests
         GO
     */
 
-        private static readonly string _connString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
+        private static readonly string _connString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!;TrustServerCertificate=True;";
         private static readonly string _tableName = "TestTable";
         private static readonly string _procedureName = "TestProcedure";
 

--- a/Frends.Community.WindowsSQL/Extensions.cs
+++ b/Frends.Community.WindowsSQL/Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 #pragma warning disable 1591
@@ -32,7 +32,7 @@ namespace Frends.Community.WindowsSQL
             FieldInfo rowsCopiedField = null;
             rowsCopiedField = typeof(SqlBulkCopy).GetField(rowsCopiedFieldName,
                 BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-            return rowsCopiedField != null ? (int)rowsCopiedField.GetValue(bulkCopy) : 0;
+            return rowsCopiedField != null ? int.Parse(rowsCopiedField.GetValue(bulkCopy).ToString()) : 0;
         }
 
         public static void SetEmptyDataRowsToNull(this DataSet dataSet)

--- a/Frends.Community.WindowsSQL/Frends.Community.WindowsSQL.csproj
+++ b/Frends.Community.WindowsSQL/Frends.Community.WindowsSQL.csproj
@@ -7,7 +7,7 @@
     <Company>HiQ Finland</Company>
     <Authors>HiQ Finland</Authors>
     <Description>Frends Sql tasks for Windows machines</Description>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Frends.Community.WindowsSQL/Frends.Community.WindowsSQL.csproj
+++ b/Frends.Community.WindowsSQL/Frends.Community.WindowsSQL.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
 	<LangVersion>Latest</LangVersion>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Company>HiQ Finland</Company>
     <Authors>HiQ Finland</Authors>
     <Description>Frends Sql tasks for Windows machines</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.60.1" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-	<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-	<PackageReference Include="SimpleImpersonation" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+	<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+	<PackageReference Include="SimpleImpersonation" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frends.Community.WindowsSQL/WindowsSQL.cs
+++ b/Frends.Community.WindowsSQL/WindowsSQL.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Dynamic;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/README.md
+++ b/README.md
@@ -189,3 +189,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 | ------- | ------- |
 | 1.0.0   | Initial implementation |
 | 1.1.0   | Added Simple impersonation to BatchOperation and BulkInsert methods |
+| 2.0.0   | Targeted to .NET6 and 8 and updated the following packages: Dapper to 2.1.35, System.Data.SqlClient to Microsoft.Data.SqlClient 5.2.2, System.ComponentModel.Annotations to 5.0.0 and SimpleImpresonation to 4.2.0 |

--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 | ------- | ------- |
 | 1.0.0   | Initial implementation |
 | 1.1.0   | Added Simple impersonation to BatchOperation and BulkInsert methods |
-| 2.0.0   | Targeted to .NET6 and 8 and updated the following packages: Dapper to 2.1.35, System.Data.SqlClient to Microsoft.Data.SqlClient 5.2.2, System.ComponentModel.Annotations to 5.0.0 and SimpleImpresonation to 4.2.0 |
+| 2.0.0   | Targeted to .NET6 and 8 and updated the following packages: Dapper to 2.1.35, System.Data.SqlClient to Microsoft.Data.SqlClient 5.2.2, System.ComponentModel.Annotations to 5.0.0 and SimpleImpersonation to 4.2.0 |


### PR DESCRIPTION
Targeted to .NET6 and 8 and updated the following packages: Dapper to 2.1.35, System.Data.SqlClient to Microsoft.Data.SqlClient 5.2.2, System.ComponentModel.Annotations to 5.0.0 and SimpleImpersonation to 4.2.0. Made some adjustments that were needed after the package updates and to get tests working.